### PR TITLE
feat: Display header 'Course Materials Assistant' on home page

### DIFF
--- a/frontend/style.css
+++ b/frontend/style.css
@@ -72,9 +72,12 @@ body {
     padding: 0;
 }
 
-/* Header - Hidden */
+/* Header */
 header {
-    display: none;
+    padding: 2rem 2rem 1.5rem 2rem;
+    text-align: center;
+    background: var(--background);
+    border-bottom: 1px solid var(--border-color);
 }
 
 header h1 {


### PR DESCRIPTION
Fixes #2

Added header "Course Materials Assistant" to the home page by making the existing header element visible.

## Changes
- Modified CSS to show header instead of hiding it
- Added proper padding and styling for header section
- Header now displays prominently at the top of the application

Generated with [Claude Code](https://claude.ai/code)