### PR TITLE
Fix: Revert header to older version while keeping theme toggle

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -29,11 +29,6 @@
     </button>
 
     <div class="container">
-        <header>
-            <h1>Course Materials Assistant</h1>
-            <p class="subtitle">Ask questions about courses, instructors, and content</p>
-        </header>
-
         <div class="main-content">
             <!-- Left Sidebar -->
             <aside class="sidebar">

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -72,29 +72,6 @@ body {
     padding: 0;
 }
 
-/* Header */
-header {
-    padding: 2rem 2rem 1.5rem 2rem;
-    text-align: center;
-    background: var(--background);
-    border-bottom: 1px solid var(--border-color);
-}
-
-header h1 {
-    font-size: 1.75rem;
-    font-weight: 700;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    margin: 0;
-}
-
-.subtitle {
-    font-size: 0.95rem;
-    color: var(--text-secondary);
-    margin-top: 0.5rem;
-}
 
 /* Main Content Area with Sidebar */
 .main-content {
@@ -851,13 +828,6 @@ details[open] .suggested-header::before {
         order: 1;
     }
     
-    header {
-        padding: 1rem;
-    }
-    
-    header h1 {
-        font-size: 1.5rem;
-    }
     
     .chat-messages {
         padding: 1rem;


### PR DESCRIPTION
This PR reverts the header to the older version as requested in issue #4.

## Changes Made:
- Removed "Course Materials Assistant" header
- Removed "Ask questions about courses" subheader
- Removed horizontal row below subheader
- Removed all associated CSS styles
- Kept theme toggle functionality intact

## Result:
The application now has a cleaner, more minimal header design while maintaining full functionality.

Closes #4

Generated with [Claude Code](https://claude.ai/code)